### PR TITLE
SVC-381 gelf support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ dist: trusty
 sudo: required
 language: python
 python:
-  - "2.7_with_system_site_packages"
-  - 3.3
   - 3.6
 env:
   - PYTHONPATH=$PYTHONPATH:$PWD
@@ -16,6 +14,7 @@ before_install:
 install:
   - pip install tornado==4.5.1 Pillow==2.9.0 coveralls
   - pip install pep8==1.6.2 pyflakes==0.8.1
+  - pip install -r requirements.txt
 before_script:
   - pep8 --exclude=test pilbox
   - pyflakes pilbox/*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_install:
   - sudo apt-get install libwebp-dev liblcms2-dev
   - sudo apt-get install python-numpy python-opencv python-pycurl
 install:
-  - pip install tornado==4.5.1 Pillow==2.9.0 coveralls
   - pip install pep8==1.6.2 pyflakes==0.8.1
   - pip install -r requirements.txt
 before_script:

--- a/circle.yml
+++ b/circle.yml
@@ -3,14 +3,14 @@ machine:
         America/New_York
     python:
         version:
-            2.7.12
+            3.6.2
 
 dependencies:
     pre:
         - sudo apt-get update
         - sudo apt-get install python-dev python-numpy python-opencv libwebp-dev
+        - pip install -r requirements.txt
 
 test:
     override:
         - python -m pilbox.test.runtests
-

--- a/pilbox/__init__.py
+++ b/pilbox/__init__.py
@@ -80,6 +80,10 @@ Versions:
   * 1.3.0: Increased Pillow to 2.9.0 and Tornado to 4.5.1
 """
 
+import os
+
+import muselog
+
 # human-readable version number
 version = "1.3.0"
 
@@ -87,4 +91,9 @@ version = "1.3.0"
 # The fourth is zero for an official release, positive for a development
 # branch, or negative for a release candidate or beta (after the base version
 # number has been incremented)
-version_info = (1, 3, 0, 0)
+version_info = (2, 0, 0, 0)
+
+
+muselog.setup_logging(root_log_level=os.environ.get("LOG_LEVEL", "INFO"),
+                      module_log_levels={"pilbox": os.environ.get("THEMUSE_LOG_LEVEL", "INFO")},
+                      console_handler_format=os.environ.get("LOG_FORMAT"))

--- a/pilbox/app.py
+++ b/pilbox/app.py
@@ -209,7 +209,7 @@ class ImageHandler(tornado.web.RequestHandler):
             raise tornado.gen.Return(resp)
         except (socket.gaierror, tornado.httpclient.HTTPError) as e:
             logger.warn("Fetch error for %s: %s",
-                        self.get_argument("url"),
+                        url,
                         str(e))
             raise errors.FetchError()
 

--- a/pilbox/app.py
+++ b/pilbox/app.py
@@ -89,7 +89,8 @@ define("quality", help="default jpeg quality, 1-99 or keep")
 define("retain", help="default adaptive retain percent, 1-99", type=int)
 define("preserve_exif", help="default behavior for exif data", type=int)
 
-logger = logging.getLogger("tornado.application")
+
+logger = logging.getLogger(__name__)
 
 
 class PilboxApplication(tornado.web.Application):

--- a/pilbox/image.py
+++ b/pilbox/image.py
@@ -36,7 +36,7 @@ try:
 except ImportError:
     cv = None
 
-logger = logging.getLogger("tornado.application")
+logger = logging.getLogger(__name__)
 
 _positions_to_ratios = {
     "top-left": (0.0, 0.0), "top": (0.5, 0.0), "top-right": (1.0, 0.0),

--- a/pilbox/test/app_test.py
+++ b/pilbox/test/app_test.py
@@ -38,7 +38,7 @@ except ImportError:
     pycurl = None
 
 
-logger = logging.getLogger("tornado.application")
+logger = logging.getLogger(__name__)
 
 
 class _AppAsyncMixin(object):
@@ -600,9 +600,9 @@ class AppUserAgentTest(AsyncHTTPTestCase, _AppAsyncMixin):
     def test_incorrect_user_agent(self):
         url = self.get_url("/test/data/test-user-agent.jpg?ua=bar")
         qs = urlencode(dict(url=url, w=1, h=1))
-        resp = self.fetch_error(404, "/?%s" % qs)
+        self.fetch_error(404, "/?%s" % qs)
 
     def test_correct_user_agent(self):
         url = self.get_url("/test/data/test-user-agent.jpg?ua=%s" % AppUserAgentTest.ua)
         qs = urlencode(dict(url=url, w=1, h=1))
-        resp = self.fetch_success("/?%s" % qs)
+        self.fetch_success("/?%s" % qs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
+tornado==4.5.1
+Pillow==2.9.0
+coveralls
+
 -e git+git://github.com/dailymuse/pygelf.git@0.4.1#egg=pygelf
 -e git+git://github.com/dailymuse/muselog.git@1.1.1#egg=muselog

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+-e git+git://github.com/dailymuse/pygelf.git@0.4.1#egg=pygelf
+-e git+git://github.com/dailymuse/muselog.git@1.1.1#egg=muselog

--- a/setup.py
+++ b/setup.py
@@ -21,17 +21,12 @@ class PilboxTest(Command):
 
 
 setup(name='pilbox',
-      version='1.3.0',
+      version='2.0.0',
       description='Pilbox is an image processing application server built on the Tornado web framework using the Pillow Imaging Library',
       long_description=readme,
       classifiers=[
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.6',
         ],
       url='https://github.com/agschwender/pilbox',
       author='Adam Gschwender',
@@ -44,7 +39,8 @@ setup(name='pilbox',
         },
       install_requires=[
         'tornado==4.5.1',
-        'Pillow==2.9.0'
+        'Pillow==2.9.0',
+        'muselog>=1.1.1'
         ],
       extras_require = {
           'Proxy': ['pycurl'],


### PR DESCRIPTION
Add gelf + muselog support

Requires major version increment, as including muselog (and potentially pygelf) restricts python version to 3.6+.

SVC-381