### PR TITLE
SVC-441 upgrade muselog to 1.2.0

### DIFF
--- a/pilbox/__init__.py
+++ b/pilbox/__init__.py
@@ -85,13 +85,13 @@ import os
 import muselog
 
 # human-readable version number
-version = "1.3.0"
+version = "2.1.0"
 
 # The first three numbers are the components of the version number.
 # The fourth is zero for an official release, positive for a development
 # branch, or negative for a release candidate or beta (after the base version
 # number has been incremented)
-version_info = (2, 0, 0, 0)
+version_info = (2, 1, 0, 0)
 
 
 muselog.setup_logging(root_log_level=os.environ.get("LOG_LEVEL", "INFO"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Pillow==2.9.0
 coveralls
 
 -e git+git://github.com/dailymuse/pygelf.git@0.4.1#egg=pygelf
--e git+git://github.com/dailymuse/muselog.git@1.1.1#egg=muselog
+-e git+git://github.com/dailymuse/muselog.git@1.2.0#egg=muselog

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ class PilboxTest(Command):
 
 
 setup(name='pilbox',
-      version='2.0.0',
+      version='2.1.0',
       description='Pilbox is an image processing application server built on the Tornado web framework using the Pillow Imaging Library',
       long_description=readme,
       classifiers=[


### PR DESCRIPTION
Use muselog 1.2.0, which adds support for GRAYLOG_ENV

SVC-441